### PR TITLE
[NOT READY] Bump and auto httpfs

### DIFF
--- a/src/functions/aliases.cpp
+++ b/src/functions/aliases.cpp
@@ -4,21 +4,21 @@
 namespace scrooge {
 void Aliases::Register(duckdb::Connection &conn, duckdb::Catalog &catalog) {
   // Register Volatility
-  auto stddev = (duckdb::AggregateFunctionCatalogEntry *)catalog.GetEntry(
+  auto &stddev = (duckdb::AggregateFunctionCatalogEntry &)catalog.GetEntry(
       *conn.context, duckdb::CatalogType::AGGREGATE_FUNCTION_ENTRY,
       DEFAULT_SCHEMA, "stddev_pop");
-  auto volatility = stddev->functions;
+  auto volatility = stddev.functions;
   volatility.name = "volatility";
   duckdb::CreateAggregateFunctionInfo volatility_info(volatility);
-  catalog.CreateFunction(*conn.context, &volatility_info);
+  catalog.CreateFunction(*conn.context, volatility_info);
 
   // Register SMA
-  auto avg = (duckdb::AggregateFunctionCatalogEntry *)catalog.GetEntry(
+  auto &avg = (duckdb::AggregateFunctionCatalogEntry &)catalog.GetEntry(
       *conn.context, duckdb::CatalogType::AGGREGATE_FUNCTION_ENTRY,
       DEFAULT_SCHEMA, "avg");
-  auto sma = avg->functions;
+  auto sma = avg.functions;
   sma.name = "sma";
   duckdb::CreateAggregateFunctionInfo sma_info(sma);
-  catalog.CreateFunction(*conn.context, &sma_info);
+  catalog.CreateFunction(*conn.context, sma_info);
 }
 } // namespace scrooge

--- a/src/functions/portfolio_frontier.cpp
+++ b/src/functions/portfolio_frontier.cpp
@@ -1,7 +1,7 @@
 #include <cmath>
 #include <vector>
 #include "functions/scanner.hpp"
-#include "duckdb/execution/operator/persistent/csv_reader_options.hpp"
+#include "duckdb/execution/operator/scan/csv/csv_reader_options.hpp"
 #include "duckdb/main/relation/read_csv_relation.hpp"
 #include "duckdb/main/relation/projection_relation.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
@@ -11,7 +11,6 @@
 
 namespace scrooge {
 
-using namespace std;
 using namespace duckdb;
 
 struct Asset {

--- a/src/functions/timebucket.cpp
+++ b/src/functions/timebucket.cpp
@@ -89,6 +89,6 @@ void TimeBucketScrooge::RegisterFunction(duckdb::Connection &conn,
       {duckdb::LogicalType::TIMESTAMP, duckdb::LogicalType::INTERVAL},
       duckdb::LogicalType::TIMESTAMP, TimeBucketFunction));
   duckdb::CreateScalarFunctionInfo timebucket_info(timebucket);
-  catalog.CreateFunction(*conn.context, &timebucket_info);
+  catalog.CreateFunction(*conn.context, timebucket_info);
 }
 } // namespace scrooge

--- a/src/scanner/yahoo_finance.cpp
+++ b/src/scanner/yahoo_finance.cpp
@@ -79,6 +79,10 @@ GeneratePlan(YahooFunctionData &bind_data) {
   bind_data.from_epoch += bind_data.increment_epoch;
   bind_data.cur_to_epoch += bind_data.increment_epoch;
 
+  if (!Catalog::TryAutoLoad(*bind_data.conn->context, "httpfs")) {
+    throw MissingExtensionException("httpfs extension is required to fetch data from https://query1.finance.yahoo.com");
+  }
+
   std::string url = "https://query1.finance.yahoo.com/v7/finance/download/" +
                     bind_data.symbol + "?period1=" + from + "&period2=" + to +
                     "&interval=" + bind_data.interval + "&events=history";

--- a/src/scanner/yahoo_finance.cpp
+++ b/src/scanner/yahoo_finance.cpp
@@ -1,11 +1,13 @@
 #include "functions/scanner.hpp"
-#include "duckdb/execution/operator/persistent/csv_reader_options.hpp"
+#include "duckdb/execution/operator/scan/csv/csv_reader_options.hpp"
 #include "duckdb/main/relation/read_csv_relation.hpp"
 #include "duckdb/main/relation/projection_relation.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 
 namespace scrooge {
+
+using namespace duckdb;
 
 int64_t IntervalInEpoch(std::string &interval) {
   // ble string checkaroo
@@ -94,7 +96,7 @@ GeneratePlan(YahooFunctionData &bind_data) {
   csv_rel->AddNamedParameter("NULLSTR", "null");
   std::vector<duckdb::unique_ptr<duckdb::ParsedExpression>> expressions;
   auto star_exp = duckdb::make_uniq<duckdb::StarExpression>(csv_rel->name);
-  std::vector<std::string> aliases;
+  vector<std::string> aliases;
   if (bind_data.symbols.size() > 1) {
     auto constant_expression =
         duckdb::make_uniq<duckdb::ConstantExpression>(bind_data.symbol);

--- a/src/scrooge_extension.cpp
+++ b/src/scrooge_extension.cpp
@@ -28,7 +28,7 @@ void ScroogeExtension::Load(DuckDB &db) {
                               {LogicalType::ANY, LogicalType::ANY,
                                LogicalType::ANY, LogicalType::VARCHAR},
                               scrooge::YahooScanner::Scan,
-                              scrooge::YahooScanner::Bind);
+                              (table_function_bind_t)scrooge::YahooScanner::Bind);
   CreateTableFunctionInfo yahoo_scanner_info(yahoo_scanner);
   catalog.CreateTableFunction(*con.context, &yahoo_scanner_info);
 
@@ -37,7 +37,7 @@ void ScroogeExtension::Load(DuckDB &db) {
       "portfolio_frontier",
       {duckdb::LogicalType::LIST(duckdb::LogicalType::VARCHAR),
        LogicalType::ANY, LogicalType::ANY, LogicalType::INTEGER},
-      scrooge::PortfolioFrontier::Scan, scrooge::PortfolioFrontier::Bind);
+      scrooge::PortfolioFrontier::Scan, (table_function_bind_t)scrooge::PortfolioFrontier::Bind);
   CreateTableFunctionInfo portfolio_frontier_info(portfolio_frontier);
   catalog.CreateTableFunction(*con.context, &portfolio_frontier_info);
 


### PR DESCRIPTION
Bumping DuckDB to v0.9.0, adapting to the relevant changes, leaving two big holes in the implementations of Combine and Finalize, for in both first.cpp and in last.cpp.

Plus using autoloading mechanism (when available) to load the required httpfs dependency.


TODO:
[] Properly implement Combine and Finalize
