### PR TITLE
fix: add missing includes for DuckDB next branch compat

### DIFF
--- a/src/functions/aliases.cpp
+++ b/src/functions/aliases.cpp
@@ -1,4 +1,5 @@
 #include "functions/functions.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "duckdb/common/helper.hpp"
 

--- a/src/functions/portfolio_frontier.cpp
+++ b/src/functions/portfolio_frontier.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/main/relation/projection_relation.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
+#include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/main/relation/aggregate_relation.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/common/helper.hpp"


### PR DESCRIPTION
The `next` branch CI fails because two source files are missing explicit includes that were previously pulled in transitively:

- **`aliases.cpp`**: `CreateAggregateFunctionInfo` has incomplete type → add `create_aggregate_function_info.hpp`
- **`portfolio_frontier.cpp`**: `ColumnRefExpression` was not declared → add `columnref_expression.hpp`

Fixes the `Build extension binaries (next)` CI jobs on linux_amd64 and linux_arm64.